### PR TITLE
added configurable token expiration time

### DIFF
--- a/config/auth.js
+++ b/config/auth.js
@@ -71,5 +71,8 @@ module.exports = {
     options: {
       secret: 'self::app.appKey'
     }
+  },
+  password_reset: {
+    expires_in_minutes: 120,
   }
 }

--- a/database/migrations/1518482210361_password_resets_schema.js
+++ b/database/migrations/1518482210361_password_resets_schema.js
@@ -8,7 +8,7 @@ class PasswordResetsSchema extends Schema {
       table.increments('id')
       table.string('email')
       table.string('token')
-      table.timestamp('created_at').nullable()
+      table.timestamps()
     })
   }
 


### PR DESCRIPTION
For security reasons tokens should not be valid forever. This commit adds a configurable token expiration time. 

It validates the token using the `password_resets.updated_at` (hence the migration file change). This is necessary since the `created_at` doesn't get updated when generating a token for an email that already has a token in the database.